### PR TITLE
refactor(README): Use more suggestive class names for the return-override example

### DIFF
--- a/src/return-override-weakmap.js
+++ b/src/return-override-weakmap.js
@@ -56,30 +56,30 @@ const makePrivateTagger = () => {
  * @template {object} V
  */
 export class WeakishMap {
-  #klass
+  #tagger
   constructor() {
-    this.#klass = makePrivateTagger();
+    this.#tagger = makePrivateTagger();
   }
   /**
    * @param {any} key
    * @returns {key is K}
    */
   has(key) {
-    return this.#klass.has(key);
+    return this.#tagger.has(key);
   }
   /**
    * @param {K} key
    * @returns {V}
    */
   get(key) {
-    return this.#klass.get(key);
+    return this.#tagger.get(key);
   }
   /**
    * @param {K} key
    * @param {V} value
    */
   set(key, value) {
-    this.#klass.set(key, value);
+    this.#tagger.set(key, value);
   }
 }
 

--- a/src/return-override-weakmap.js
+++ b/src/return-override-weakmap.js
@@ -1,11 +1,11 @@
-class Superclass {
+class Trojan {
   constructor(key) {
     return key;
   }
 }
 
-const makeSubclass = () => {
-  return class Subclass extends Superclass {
+const makePrivateTagger = () => {
+  return class PrivateTagger extends Trojan {
     #value
     constructor(key, value) {
       super(key);
@@ -13,7 +13,7 @@ const makeSubclass = () => {
     }
     /**
      * @param {any} key
-     * @returns {key is Subclass}
+     * @returns {key is PrivateTagger}
      */
     static has(key) {
       try {
@@ -24,7 +24,7 @@ const makeSubclass = () => {
       }
     }
     /**
-     * @param {Subclass} key
+     * @param {PrivateTagger} key
      */
     static get(key) {
       try {
@@ -34,11 +34,11 @@ const makeSubclass = () => {
       }
     }
     /**
-     * @param {Subclass} key
+     * @param {PrivateTagger} key
      * @param {any} value
      */
     static set(key, value) {
-      new Subclass(key, value);
+      new PrivateTagger(key, value);
     }
   };
 }
@@ -58,7 +58,7 @@ const makeSubclass = () => {
 export class WeakishMap {
   #klass
   constructor() {
-    this.#klass = makeSubclass();
+    this.#klass = makePrivateTagger();
   }
   /**
    * @param {any} key


### PR DESCRIPTION
Renames `Superclass` to `Trojan` and `Subclass` to `PrivateTagger` (although `Trojan` could also plausibly be `Smuggler`).

Also adds `delete` to **return-override-weakmap.js**.